### PR TITLE
Make buildenv portable for bash compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ install/
 testing/*.o
 testing/newiosvctest
 testing/__pycache__/
+.zdx.json

--- a/buildenv
+++ b/buildenv
@@ -5,8 +5,8 @@ C3270_SVERSION="$(echo $C3270_VERSION | cut -d 'g' -f 1)"
 export ZOPEN_CATEGORIES="utilities"
 export ZOPEN_STABLE_URL="https://sourceforge.net/projects/x3270/files/x3270/${C3270_VERSION}/suite3270-${C3270_VERSION}-src.tgz"
 
-rm "suite3270-${C3270_VERSION}-src"
-ln -s "suite3270-${C3270_SVERSION}"  "suite3270-${C3270_VERSION}-src"
+rm -f "suite3270-${C3270_VERSION}-src"
+ln -sfn "suite3270-${C3270_SVERSION}" "suite3270-${C3270_VERSION}-src"
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_NAME=c3270
 export ZOPEN_STABLE_DEPS="curl zoslib make ncurses coreutils openssl less check_python"
@@ -31,14 +31,14 @@ zopen_check_results()
   echo "expectedTotalTests:1"
 }
 
-zopen_append_to_env()
-{
+zopen_append_to_env() {
   # echo envars outside of PATH, MANPATH, LIBPATH
+  return
 }
 
-zopen_append_to_setup()
-{
+zopen_append_to_setup() {
   # echo commands that will run when installing via setup.sh
+  return
 }
 
 zopen_get_version()


### PR DESCRIPTION
This PR makes the buildenv file compatible with both bash (used on desktop systems) and UNIX System Services 'sh' (used on z/OS).

## Changes

1. **Added `return` statements to functions** - Functions in buildenv now include explicit `return` statements, allowing the file to be sourced by bash without errors. Previously, the buildenv could only be sourced by z/OS USS 'sh'.

2. **Added .zdx.json to .gitignore** - The .zdx.json file contains user-specific configuration and should not be tracked in version control.

## Benefits

- Enables desktop-based port development workflow using `localzopen` commands
- Allows developers to source buildenv on their local machines for testing
- Maintains full compatibility with z/OS USS 'sh'
- Improves developer experience for zopen port contributors

## Testing

Verified that buildenv can now be sourced successfully on macOS with bash:
```bash
source ./buildenv  # No errors
```